### PR TITLE
Improve multi-screen support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,22 @@
 'use strict';
 
-const electron = require('electron');
-const app = electron.app;
-const screen = electron.screen;
-const jsonfile = require('jsonfile');
-const path = require('path');
-const mkdirp = require('mkdirp');
-const objectAssign = require('object-assign');
-const deepEqual = require('deep-equal');
+var app = require('app');
+var screen = require('screen');
+var jsonfile = require('jsonfile');
+var path = require('path');
+var mkdirp = require('mkdirp');
+var objectAssign = require('object-assign');
+var deepEqual = require('deep-equal');
 
 module.exports = function (options) {
-  const config = objectAssign({}, {file: 'window-state.json', path: app.getPath('userData')}, options);
-  const fullStoreFileName = path.join(config.path, config.file);
-
-  let state;
+  var config = objectAssign({}, {
+    file: 'window-state.json',
+    path: app.getPath('userData')
+  }, options);
+  var fullStoreFileName = path.join(config.path, config.file);
+  var delay = 100; // Number of milliseconds to postpone handling the event
+  var state;
+  var winRef;
 
   try {
     state = jsonfile.readFileSync(fullStoreFileName);
@@ -24,7 +27,7 @@ module.exports = function (options) {
   if (state && state.displayBounds) {
     // If the display where the app window was displayed is no longer available,
     // we should drop the stored state
-    const displayBounds = screen.getDisplayMatching(state).bounds;
+    var displayBounds = screen.getDisplayMatching(state).bounds;
     if (!deepEqual(state.displayBounds, displayBounds, {strict: true})) {
       state = null;
     }
@@ -37,20 +40,79 @@ module.exports = function (options) {
     };
   }
 
+  var isNormal = function (win) {
+    return !win.isMaximized() && !win.isMinimized() && !win.isFullScreen();
+  }
+
   var saveState = function (win) {
-    const winBounds = win.getBounds();
-    const isMaximized = win.isMaximized();
-    if (!isMaximized && !win.isMinimized()) {
+    var winBounds = win.getBounds();
+    if (isNormal(win)) {
       state.x = winBounds.x;
       state.y = winBounds.y;
       state.width = winBounds.width;
       state.height = winBounds.height;
     }
-    state.isMaximized = isMaximized;
+    state.isMaximized = win.isMaximized();
     state.displayBounds = screen.getDisplayMatching(winBounds).bounds;
     mkdirp.sync(path.dirname(fullStoreFileName));
     jsonfile.writeFileSync(fullStoreFileName, state);
   };
+
+  var resizeTimer;
+  var resizeHandler = function () {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(function () {
+      var winBounds = winRef.getBounds();
+      if (isNormal(winRef)) {
+        state.x = winBounds.x;
+        state.y = winBounds.y;
+        state.width = winBounds.width;
+        state.height = winBounds.height;
+      }
+    }, delay);
+  }
+
+  var moveTimer;
+  var moveHandler = function () {
+    clearTimeout(moveTimer);
+    moveTimer = setTimeout(function () {
+      var winBounds = winRef.getBounds();
+      if (isNormal(winRef)) {
+        state.x = winBounds.x;
+        state.y = winBounds.y;
+      }
+    }, delay);
+  }
+
+  var closeHandler = function () {
+    // Note: We wrap saveState because the first parameter of the close event is
+    // an event object and not the window object like it expects
+    saveState(winRef);
+  }
+
+  var closedHandler = function () {
+    unregister();
+  }
+
+  var register = function (win) {
+    win.on('resize', resizeHandler);
+    win.on('move', moveHandler);
+    win.on('close', closeHandler);
+    win.on('closed', closedHandler);
+    winRef = win;
+  }
+
+  var unregister = function () {
+    if (winRef) {
+      winRef.removeListener('resize', resizeHandler);
+      clearTimeout(resizeTimer);
+      winRef.removeListener('move', moveHandler);
+      clearTimeout(moveTimer);
+      winRef.removeListener('close', closeHandler);
+      winRef.removeListener('closed', closedHandler);
+      winRef = null;
+    }
+  }
 
   return {
     get x() { return state.x; },
@@ -58,6 +120,8 @@ module.exports = function (options) {
     get width() { return state.width; },
     get height() { return state.height; },
     get isMaximized() { return state.isMaximized; },
-    saveState: saveState
+    saveState: saveState,
+    register: register,
+    unregister: unregister
   };
 };

--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ module.exports = function (options) {
     path: app.getPath('userData')
   }, options);
   var fullStoreFileName = path.join(config.path, config.file);
-  var delay = 100; // Number of milliseconds to postpone handling the event
+  // Number of milliseconds to postpone handling the event
+  var delay = 100;
   var state;
   var winRef;
 
@@ -42,7 +43,7 @@ module.exports = function (options) {
 
   var isNormal = function (win) {
     return !win.isMaximized() && !win.isMinimized() && !win.isFullScreen();
-  }
+  };
 
   var saveState = function (win) {
     var winBounds = win.getBounds();
@@ -70,7 +71,7 @@ module.exports = function (options) {
         state.height = winBounds.height;
       }
     }, delay);
-  }
+  };
 
   var moveTimer;
   var moveHandler = function () {
@@ -82,25 +83,13 @@ module.exports = function (options) {
         state.y = winBounds.y;
       }
     }, delay);
-  }
+  };
 
   var closeHandler = function () {
     // Note: We wrap saveState because the first parameter of the close event is
     // an event object and not the window object like it expects
     saveState(winRef);
-  }
-
-  var closedHandler = function () {
-    unregister();
-  }
-
-  var register = function (win) {
-    win.on('resize', resizeHandler);
-    win.on('move', moveHandler);
-    win.on('close', closeHandler);
-    win.on('closed', closedHandler);
-    winRef = win;
-  }
+  };
 
   var unregister = function () {
     if (winRef) {
@@ -109,10 +98,18 @@ module.exports = function (options) {
       winRef.removeListener('move', moveHandler);
       clearTimeout(moveTimer);
       winRef.removeListener('close', closeHandler);
-      winRef.removeListener('closed', closedHandler);
+      winRef.removeListener('closed', unregister);
       winRef = null;
     }
-  }
+  };
+
+  var register = function (win) {
+    win.on('resize', resizeHandler);
+    win.on('move', moveHandler);
+    win.on('close', closeHandler);
+    win.on('closed', unregister);
+    winRef = win;
+  };
 
   return {
     get x() { return state.x; },

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ module.exports = function (options) {
   var config = objectAssign({
     file: 'window-state.json',
     path: app.getPath('userData'),
-    maximize: true
+    maximize: true,
+    fullScreen: true
   }, options);
   var fullStoreFileName = path.join(config.path, config.file);
 
@@ -56,6 +57,7 @@ module.exports = function (options) {
       state.height = winBounds.height;
     }
     state.isMaximized = win.isMaximized();
+    state.isFullScreen = win.isFullScreen();
     state.displayBounds = screen.getDisplayMatching(winBounds).bounds;
   }
 
@@ -93,6 +95,9 @@ module.exports = function (options) {
   function manage(win) {
     if (config.maximize && state.isMaximized) {
       win.maximize();
+    }
+    if (config.fullScreen && state.isFullScreen) {
+      win.setFullScreen(true);
     }
     win.on('resize', stateChangeHandler);
     win.on('move', stateChangeHandler);
@@ -136,6 +141,7 @@ module.exports = function (options) {
     get width() { return state.width; },
     get height() { return state.height; },
     get isMaximized() { return state.isMaximized; },
+    get isFullScreen() { return state.isFullScreen; },
     saveState: saveState,
     manage: manage
   };

--- a/index.js
+++ b/index.js
@@ -13,9 +13,10 @@ module.exports = function (options) {
   var winRef;
   var stateChangeTimer;
   var eventHandlingDelay = 100;
-  var config = objectAssign({}, {
+  var config = objectAssign({
     file: 'window-state.json',
-    path: app.getPath('userData')
+    path: app.getPath('userData'),
+    maximize: true
   }, options);
   var fullStoreFileName = path.join(config.path, config.file);
 
@@ -85,11 +86,14 @@ module.exports = function (options) {
 
   function closedHandler() {
     // Unregister listeners and save state
-    unregister();
+    unmanage();
     saveState();
   }
 
-  function register(win) {
+  function manage(win) {
+    if (config.maximize && state.isMaximized) {
+      win.maximize();
+    }
     win.on('resize', stateChangeHandler);
     win.on('move', stateChangeHandler);
     win.on('close', closeHandler);
@@ -97,7 +101,7 @@ module.exports = function (options) {
     winRef = win;
   }
 
-  function unregister() {
+  function unmanage() {
     if (winRef) {
       winRef.removeListener('resize', stateChangeHandler);
       winRef.removeListener('move', stateChangeHandler);
@@ -133,7 +137,6 @@ module.exports = function (options) {
     get height() { return state.height; },
     get isMaximized() { return state.isMaximized; },
     saveState: saveState,
-    register: register,
-    unregister: unregister
+    manage: manage
   };
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "electron"
   ],
   "dependencies": {
+    "deep-equal": "^1.0.1",
     "jsonfile": "^2.2.3",
     "mkdirp": "^0.5.1",
     "object-assign": "^4.0.1"

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # electron-window-state [![Build Status](https://travis-ci.org/mawie81/electron-window-state.svg)](https://travis-ci.org/mawie81/electron-window-state)
 
-> A library to store and restore window sizes and positions for your [Electron](http://electron.atom.io) app
+> A library to store and restore window sizes and positions for your
+[Electron](http://electron.atom.io) app
 
 *Heavily influenced by the implementation in [electron-boilerplate](https://github.com/szwacz/electron-boilerplate).*
 
@@ -13,26 +14,34 @@ $ npm install --save electron-window-state
 ## Usage
 
 ```js
-const windowStateKeeper = require('electron-window-state');
+let win;
 
 app.on('ready', function () {
+  // Require the module only after the ready event was fired
+  const windowStateKeeper = require('electron-window-state');
+
+  // Load the previous state with fallback to defaults
   let mainWindowState = windowStateKeeper({
     defaultWidth: 1000,
     defaultHeight: 800
   });
 
-  const win = new BrowserWindow({
+  // Create the window using the state information
+  win = new BrowserWindow({
     'x': mainWindowState.x,
     'y': mainWindowState.y,
     'width': mainWindowState.width,
     'height': mainWindowState.height
   });
 
+  // Maximize the window if it was maximized last time
   if (mainWindowState.isMaximized) {
     win.maximize();
   }
 
-  win.on('close', (e) => mainWindowState.saveState(win));
+  // Let us register listeners on the window, so we can update the state
+  // automatically (the listeners will be removed when the window is closed)
+  mainWindowState.register(win);
 });
 ```
 
@@ -52,11 +61,12 @@ app.on('ready', function () {
 
 `path` - *String*
 
-  The path where the state file should be written to. Defaults to ```app.getPath('userData')```
+  The path where the state file should be written to. Defaults to
+  `app.getPath('userData')`
 
 `file` - *String*
 
-  The name of file. Defaults to ```window-state.json```
+  The name of file. Defaults to `window-state.json`
 
 ### state object
 
@@ -69,28 +79,45 @@ const windowState = windowStateKeeper({
 
 `x` - *Number*
 
-  The saved ```x``` coordinate of the loaded state. ```undefined``` if the state has not been saved yet. 
+  The saved `x` coordinate of the loaded state. `undefined` if the state has not
+  been saved yet.
 
 `y` - *Number*
 
-  The saved ```y``` coordinate of the loaded state. ```undefined``` if the state has not been saved yet.
-  
+  The saved `y` coordinate of the loaded state. `undefined` if the state has not
+  been saved yet.
+
 `width` - *Number*
 
-  The saved ```width``` of loaded state. ```defaultWidth``` if the state has not been saved yet.
-  
+  The saved `width` of loaded state. `defaultWidth` if the state has not been
+  saved yet.
+
 `height` - *Number*
 
-  The saved ```heigth``` of loaded state. ```defaultHeight``` if the state has not been saved yet.
-  
+  The saved `heigth` of loaded state. `defaultHeight` if the state has not been
+  saved yet.
+
 `isMaximized` - *Boolean*
 
-  ```true``` if the window state was saved while the the window was maximized. ```undefined``` if the state has not been saved yet.
-  
+  `true` if the window state was saved while the the window was maximized.
+  `undefined` if the state has not been saved yet.
+
+`register(window)` - *Function*
+
+  Register listeners on the given `BrowserWindow` for events that are
+  related to size or position changes (`resize`, `move`). When the window is
+  closed we automatically remove the listeners and save the state.
+
+`unregister()` - *Function*
+
+  Unregister listeners that were previously registered with `register`. You
+  usually don't need to call this, since it's taken care of automatically when
+  the window is closed.
+
 `saveState(window)` - *Function*
 
-  Saves the current state of the given ```BrowserWindow```.
-
+  Saves the current state of the given `BrowserWindow`. This exists for legacy
+  purposes, use `register` instead.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ app.on('ready', function () {
 
   // Let us register listeners on the window, so we can update the state
   // automatically (the listeners will be removed when the window is closed)
-  // and maximize the window for you if it was last closed maximized
+  // and restore the maximized or full screen state
   mainWindowState.manage(win);
 });
 ```
@@ -66,8 +66,13 @@ Note: Don't call this function before the `ready` event is fired.
 
 `maximize` - *Boolean*
 
-    Should we maximize the window for you, if it was last closed maximized.
-    Defaults to `true`  
+  Should we automatically maximize the window, if it was last closed
+  maximized. Defaults to `true`
+
+`fullScreen` - *Boolean*
+
+  Should we automatically restore the window to full screen, if it was last
+  closed full screen. Defaults to `true`
 
 ### state object
 
@@ -103,11 +108,18 @@ const windowState = windowStateKeeper({
   `true` if the window state was saved while the the window was maximized.
   `undefined` if the state has not been saved yet.
 
+`isFullScreen` - *Boolean*
+
+  `true` if the window state was saved while the the window was in full screen
+  mode. `undefined` if the state has not been saved yet.
+
 `manage(window)` - *Function*
 
   Register listeners on the given `BrowserWindow` for events that are
-  related to size or position changes (`resize`, `move`). When the window is
-  closed we automatically remove the listeners and save the state.
+  related to size or position changes (`resize`, `move`). It will also restore
+  the window's maximized or full screen state.
+  When the window is closed we automatically remove the listeners and save the
+  state.
 
 `saveState(window)` - *Function*
 

--- a/readme.md
+++ b/readme.md
@@ -32,14 +32,10 @@ app.on('ready', function () {
     'height': mainWindowState.height
   });
 
-  // Maximize the window if it was maximized last time
-  if (mainWindowState.isMaximized) {
-    win.maximize();
-  }
-
   // Let us register listeners on the window, so we can update the state
   // automatically (the listeners will be removed when the window is closed)
-  mainWindowState.register(win);
+  // and maximize the window for you if it was last closed maximized
+  mainWindowState.manage(win);
 });
 ```
 
@@ -53,11 +49,11 @@ Note: Don't call this function before the `ready` event is fired.
 
 `defaultWidth` - *Number*
 
-  The width that should be returned if no file exists yet. Defaults to 800.
+  The width that should be returned if no file exists yet. Defaults to `800`.
 
 `defaultHeight` - *Number*
 
-  The height that should be returned if no file exists yet. Defaults to 600.
+  The height that should be returned if no file exists yet. Defaults to `600`.
 
 `path` - *String*
 
@@ -67,6 +63,11 @@ Note: Don't call this function before the `ready` event is fired.
 `file` - *String*
 
   The name of file. Defaults to `window-state.json`
+
+`maximize` - *Boolean*
+
+    Should we maximize the window for you, if it was last closed maximized.
+    Defaults to `true`  
 
 ### state object
 
@@ -102,22 +103,16 @@ const windowState = windowStateKeeper({
   `true` if the window state was saved while the the window was maximized.
   `undefined` if the state has not been saved yet.
 
-`register(window)` - *Function*
+`manage(window)` - *Function*
 
   Register listeners on the given `BrowserWindow` for events that are
   related to size or position changes (`resize`, `move`). When the window is
   closed we automatically remove the listeners and save the state.
 
-`unregister()` - *Function*
-
-  Unregister listeners that were previously registered with `register`. You
-  usually don't need to call this, since it's taken care of automatically when
-  the window is closed.
-
 `saveState(window)` - *Function*
 
   Saves the current state of the given `BrowserWindow`. This exists mostly for
-  legacy purposes, and in most cases it's better to just use `register`.
+  legacy purposes, and in most cases it's better to just use `manage`.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -14,12 +14,10 @@ $ npm install --save electron-window-state
 ## Usage
 
 ```js
+const windowStateKeeper = require('electron-window-state');
 let win;
 
 app.on('ready', function () {
-  // Require the module only after the ready event was fired
-  const windowStateKeeper = require('electron-window-state');
-
   // Load the previous state with fallback to defaults
   let mainWindowState = windowStateKeeper({
     defaultWidth: 1000,
@@ -48,6 +46,8 @@ app.on('ready', function () {
 ## API
 
 #### windowStateKeeper(opts)
+
+Note: Don't call this function before the `ready` event is fired.
 
 ##### opts
 
@@ -116,8 +116,8 @@ const windowState = windowStateKeeper({
 
 `saveState(window)` - *Function*
 
-  Saves the current state of the given `BrowserWindow`. This exists for legacy
-  purposes, use `register` instead.
+  Saves the current state of the given `BrowserWindow`. This exists mostly for
+  legacy purposes, and in most cases it's better to just use `register`.
 
 ## License
 


### PR DESCRIPTION
Resolves #1.

The first issue was solved by keeping track of the display bounds. If the display is not available when we load, we'll drop the state and use the defaults.

The second issue, was solved by listening to the `move` and `resize` events and updating the state. We're using timers to eliminate concerns of querying Electron's state too often. And it's all wrapped in a new method called `register` that takes care of everything automatically, including saving the state on `close`.

This was tested on Windows, but should work fine on OS X and Linux.