### PR TITLE
Allow manual suspension of window state saving

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,6 +143,7 @@ module.exports = function (options) {
     get isMaximized() { return state.isMaximized; },
     get isFullScreen() { return state.isFullScreen; },
     saveState: saveState,
+    unmanage: unmanage,
     manage: manage
   };
 };


### PR DESCRIPTION
For if you'd like to take control of the window's position and no longer wish to have its state managed.

I.e. window is a fixed-size in a specific state, but resizable in another state.