### PR TITLE
Fix loading old modules removed in Electron v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "5"
 
 branches:
   only:

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var app = require('app');
+var electron = require('electron');
+var app = electron.app;
 var jsonfile = require('jsonfile');
 var path = require('path');
 var mkdirp = require('mkdirp');
@@ -8,7 +9,7 @@ var objectAssign = require('object-assign');
 var deepEqual = require('deep-equal');
 
 module.exports = function (options) {
-  var screen = require('screen');
+  var screen = electron.screen;
   var state;
   var winRef;
   var stateChangeTimer;

--- a/test.js
+++ b/test.js
@@ -7,9 +7,12 @@ test.before(() => {
     writeFileSync: function () {},
     readFileSync: function () {}
   };
+  const electronMock = {
+    app: {getPath: function () {return '/temp';}},
+    screen: {getDisplayMatching: function () {}}
+  };
   mockery.registerAllowables(['./', 'path', 'object-assign', 'deep-equal', 'sinon', './lib/keys.js', './lib/is_arguments.js']);
-  mockery.registerMock('app', {getPath: function () {return '/temp';}});
-  mockery.registerMock('screen', {getDisplayMatching: function () {}});
+  mockery.registerMock('electron', electronMock);
   mockery.registerMock('mkdirp', {sync: function () {}});
   mockery.registerMock('jsonfile', jsonfileMock);
   mockery.enable({useCleanCache: true});
@@ -103,7 +106,7 @@ test('saves the state to the file system', t => {
   const jsonfile = require('jsonfile');
   sinon.spy(jsonfile, 'writeFileSync');
 
-  const screen = require('screen');
+  const screen = require('electron').screen;
   sinon.stub(screen, 'getDisplayMatching').returns({bounds: screenBounds});
 
   const state = require('./')({defaultWidth: 1000, defaultHeight: 2000});


### PR DESCRIPTION
Electron v1.0.0 was out and deprecated modules are removed.
I fixed requiring deprecated module.

https://github.com/electron/electron/pull/5373