### PR TITLE
Consider a state without bounds still valid if fullscreen of maximized

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,8 @@ module.exports = function (options) {
   }
 
   function validateState() {
-    var isValid = state && hasBounds();
-    if (isValid && state.displayBounds) {
+    var isValid = state && (hasBounds() || state.isMaximized || state.isFullScreen);
+    if (hasBounds() && state.displayBounds) {
       // Check if the display where the window was last open is still available
       var displayBounds = screen.getDisplayMatching(state).bounds;
       isValid = deepEqual(state.displayBounds, displayBounds, {strict: true});

--- a/test.js
+++ b/test.js
@@ -47,6 +47,52 @@ test('tries to read state file from the configured source', t => {
   jsonfile.readFileSync.restore();
 });
 
+test('considers the state invalid if without bounds', t => {
+  const jsonfile = require('jsonfile');
+  sinon.stub(jsonfile, 'readFileSync').returns({
+    width: 100
+  });
+
+  const state = require('./')({
+    defaultWidth: 200
+  });
+
+  t.not(state.width, 100);
+  jsonfile.readFileSync.restore();
+});
+
+test('considers the state valid if without bounds but isMaximized is true', t => {
+  const jsonfile = require('jsonfile');
+  sinon.stub(jsonfile, 'readFileSync').returns({
+    isMaximized: true,
+    width: 100
+  });
+
+  const state = require('./')({
+    defaultWidth: 200
+  });
+
+  t.true(state.isMaximized);
+  t.is(state.width, 100);
+  jsonfile.readFileSync.restore();
+});
+
+test('considers the state valid if without bounds but isFullScreen is true', t => {
+  const jsonfile = require('jsonfile');
+  sinon.stub(jsonfile, 'readFileSync').returns({
+    isFullScreen: true,
+    width: 100
+  });
+
+  const state = require('./')({
+    defaultWidth: 200
+  });
+
+  t.true(state.isFullScreen);
+  t.is(state.width, 100);
+  jsonfile.readFileSync.restore();
+});
+
 test('returns the defaults if the state in the file is invalid', t => {
   const jsonfile = require('jsonfile');
   sinon.stub(jsonfile, 'readFileSync').returns({});


### PR DESCRIPTION
The state will have it's coordinates and size info updated only if the
app is not in fullscreen mode or maximized at the time of the update.

This makes sense because coordinates and size are not relevant when in
fullscreen or maximized. The problem is that only the defaultWidth and
defaultHeight definitions will be read if the state in the file is not
considered valid, and to be considered valid, a state must have bounds
(x, y, width and height must be defined).

When leaving the application for the first time (no preexistent
window-store.json), if the application was in fullscreen mode or
maximized when exiting, the newly created window-store.json will not
have coordinates and size info (since the update function that is called
right before the save operation will ignore the coordinates and size, as
said before).

Because of that, when the application is opened for the second time, the
state is considered invalid and the saved isMaximized or
isFullScreen options are completely ignored.

This fixes that by considering the state valid if isFullScreen or
isMaximized are true, even if it has no bounds. It also adds some basic
tests to this functionality.

I noticed this problem when I was trying to follow Nyaovim's documentation on it's [browser-config.json](https://github.com/rhysd/NyaoVim/blob/master/docs/browser-config.md) file and `remember_window_state` wasn't working as expected. I dug a little on Nyaovim's source and eventually found that when the `remember_window_state`was set to true, it basically turned on `electron-window-state`. So I started digging here as well initially so that I could open an issue with some useful info instead of a simple "this ain't working".

The damn bug ended up being so erratic that it wasn't until I actually found the problem on the code that I understood how to reproduce it and what was really happening. By that time, I figured it was easier to fork the repo and make a pull request. :smile: 