### PR TITLE
Try to keep as state as possible when the display changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function (options) {
       var displayBounds = screen.getDisplayMatching(state).bounds;
       var sameBounds = deepEqual(state.displayBounds, displayBounds, {strict: true});
       if (!sameBounds) {
-        if (displayBounds.width < state.displayBounds) {
+        if (displayBounds.width < state.displayBounds.width) {
           if (state.x > displayBounds.width) {
             state.x = null;
           }
@@ -56,7 +56,7 @@ module.exports = function (options) {
           }
         }
 
-        if (displayBounds.height < state.displayBounds) {
+        if (displayBounds.height < state.displayBounds.height) {
           if (state.y > displayBounds.height) {
             state.y = null;
           }

--- a/index.js
+++ b/index.js
@@ -36,12 +36,37 @@ module.exports = function (options) {
 
   function validateState() {
     var isValid = state && (hasBounds() || state.isMaximized || state.isFullScreen);
+    if (!isValid) {
+      state = null;
+      return;
+    }
+
     if (hasBounds() && state.displayBounds) {
       // Check if the display where the window was last open is still available
       var displayBounds = screen.getDisplayMatching(state).bounds;
-      isValid = deepEqual(state.displayBounds, displayBounds, {strict: true});
+      var sameBounds = deepEqual(state.displayBounds, displayBounds, {strict: true});
+      if (!sameBounds) {
+        if (displayBounds.width < state.displayBounds) {
+          if (state.x > displayBounds.width) {
+            state.x = null;
+          }
+
+          if (state.width > displayBounds.width) {
+            state.width = displayBounds.width;
+          }
+        }
+
+        if (displayBounds.height < state.displayBounds) {
+          if (state.y > displayBounds.height) {
+            state.y = null;
+          }
+
+          if (state.height > displayBounds.height) {
+            state.height = displayBounds.height;
+          }
+        }
+      }
     }
-    return isValid;
   }
 
   function updateState(win) {
@@ -126,9 +151,7 @@ module.exports = function (options) {
   }
 
   // Check state validity
-  if (!validateState()) {
-    state = null;
-  }
+  validateState();
 
   // Set state fallback values
   state = objectAssign({


### PR DESCRIPTION
👋 

If the user launches the app on a different screen, try to keep all their state if possible, clamping it as needed.

Otherwise the app keeps resetting the window state without any real need.