### PR TITLE
Update deps and tests, remove object-assign polyfill

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "5"
+  - "6"
+  - "node"
 
 branches:
   only:

--- a/index.js
+++ b/index.js
@@ -1,20 +1,19 @@
 'use strict';
 
-var electron = require('electron');
-var app = electron.app;
-var jsonfile = require('jsonfile');
 var path = require('path');
+var electron = require('electron');
+var jsonfile = require('jsonfile');
 var mkdirp = require('mkdirp');
-var objectAssign = require('object-assign');
 var deepEqual = require('deep-equal');
 
 module.exports = function (options) {
+  var app = electron.app;
   var screen = electron.screen;
   var state;
   var winRef;
   var stateChangeTimer;
   var eventHandlingDelay = 100;
-  var config = objectAssign({
+  var config = Object.assign({
     file: 'window-state.json',
     path: app.getPath('userData'),
     maximize: true,
@@ -97,7 +96,7 @@ module.exports = function (options) {
     try {
       mkdirp.sync(path.dirname(fullStoreFileName));
       jsonfile.writeFileSync(fullStoreFileName, state);
-    } catch (e) {
+    } catch (err) {
       // Don't care
     }
   }
@@ -154,7 +153,7 @@ module.exports = function (options) {
   validateState();
 
   // Set state fallback values
-  state = objectAssign({
+  state = Object.assign({
     width: config.defaultWidth || 800,
     height: config.defaultHeight || 600
   }, state);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "author": "Marcel Wiehle",
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=4.0.0"
   },
   "scripts": {
     "test": "xo && ava"
@@ -21,14 +21,13 @@
   "dependencies": {
     "deep-equal": "^1.0.1",
     "jsonfile": "^2.2.3",
-    "mkdirp": "^0.5.1",
-    "object-assign": "^4.0.1"
+    "mkdirp": "^0.5.1"
   },
   "devDependencies": {
-    "ava": "^0.7.0",
+    "ava": "^0.17.0",
     "mockery": "^1.4.0",
     "sinon": "^1.17.2",
-    "xo": "^0.11.2"
+    "xo": "^0.17.1"
   },
   "xo": {
     "space": true,

--- a/test.js
+++ b/test.js
@@ -126,8 +126,8 @@ test('maximize and set the window fullscreen if enabled', t => {
   const state = require('./')({defaultWidth: 1000, defaultHeight: 2000});
   state.manage(win);
 
-  t.ok(win.maximize.calledOnce);
-  t.ok(win.setFullScreen.calledOnce);
+  t.truthy(win.maximize.calledOnce);
+  t.truthy(win.setFullScreen.calledOnce);
   jsonfile.readFileSync.restore();
 });
 
@@ -158,8 +158,8 @@ test('saves the state to the file system', t => {
   const state = require('./')({defaultWidth: 1000, defaultHeight: 2000});
   state.saveState(win);
 
-  t.ok(mkdirp.sync.calledOnce);
-  t.ok(jsonfile.writeFileSync.calledWith('/temp/window-state.json', {
+  t.truthy(mkdirp.sync.calledOnce);
+  t.truthy(jsonfile.writeFileSync.calledWith('/temp/window-state.json', {
     x: 100,
     y: 100,
     width: 500,


### PR DESCRIPTION
Node.js v6 is LTS version now. Electron base on Node.js v6 from Electron v1.0, now v1.4.7. So I think we can drop support for old node.js.

Some code reordering and renaming because of `xo` linting