### PR TITLE
set x/y to `0` instead of `null` ...

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = function (options) {
       if (!sameBounds) {
         if (displayBounds.width < state.displayBounds.width) {
           if (state.x > displayBounds.width) {
-            state.x = null;
+            state.x = 0;
           }
 
           if (state.width > displayBounds.width) {
@@ -57,7 +57,7 @@ module.exports = function (options) {
 
         if (displayBounds.height < state.displayBounds.height) {
           if (state.y > displayBounds.height) {
-            state.y = null;
+            state.y = 0;
           }
 
           if (state.height > displayBounds.height) {


### PR DESCRIPTION
... if current value is out of current displayBounds.
(`null` crashes `screen.getDisplayMatching()`)

Should fix https://github.com/mawie81/electron-window-state/issues/15