### PR TITLE
Fix: corrupted x,y in window-state.json trigger runtime error

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,10 +27,10 @@ module.exports = function (options) {
 
   function hasBounds() {
     return state &&
-      state.x !== undefined &&
-      state.y !== undefined &&
-      state.width !== undefined &&
-      state.height !== undefined;
+      Number.isInteger(state.x) &&
+      Number.isInteger(state.y) &&
+      Number.isInteger(state.width) &&
+      Number.isInteger(state.height);
   }
 
   function validateState() {


### PR DESCRIPTION
On multi-screen configuration `null` might be assigned to x or y (before https://github.com/mawie81/electron-window-state/releases/tag/v4.0.1) in window-state.json and will prevent electron app to open properly next time it will be run.

This PR might fix https://github.com/mawie81/electron-window-state/issues/19