### PR TITLE
Add check for width/height zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ module.exports = function (options) {
     return state &&
       Number.isInteger(state.x) &&
       Number.isInteger(state.y) &&
-      Number.isInteger(state.width) &&
-      Number.isInteger(state.height);
+      Number.isInteger(state.width) && state.width > 0 &&
+      Number.isInteger(state.height) && state.height > 0;
   }
 
   function validateState() {


### PR DESCRIPTION
I had the same issue as #18, with the window being set to width/height zero when using a second monitor as primary display, on macOS. Adding this check in `hasBounds()` solved it for me.