### PR TITLE
Add defaultX/defaultY options for setting default position of window

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import * as Electron from 'electron'
+import * as Electron from 'electron';
 
 declare function windowStateKeeper(opts: windowStateKeeper.Options): windowStateKeeper.State;
 
@@ -15,12 +15,16 @@ declare namespace windowStateKeeper {
         file?: string;
         /** Should we automatically maximize the window, if it was last closed maximized. Defaults to `true`. */
         maximize?: boolean;
+        /** The X position that should be returned if no file exists yet. Defaults to `0`. */
+        defaultX?: number | undefined;
+        /** The Y position that should be returned if no file exists yet. Defaults to `0`. */
+        defaultY?: number | undefined;
     }
 
     interface State {
         displayBounds: {
-          height: number;
-          width: number;
+            height: number;
+            width: number;
         };
         /** The saved height of loaded state. `defaultHeight` if the state has not been saved yet. */
         height: number;

--- a/index.js
+++ b/index.js
@@ -16,7 +16,9 @@ module.exports = function (options) {
     file: 'window-state.json',
     path: app.getPath('userData'),
     maximize: true,
-    fullScreen: true
+    fullScreen: true,
+    defaultX: 0,
+    defaultY: 0
   }, options);
   const fullStoreFileName = path.join(config.path, config.file);
 
@@ -39,8 +41,8 @@ module.exports = function (options) {
     state = {
       width: config.defaultWidth || 800,
       height: config.defaultHeight || 600,
-      x: 0,
-      y: 0,
+      x: 'defaultX' in config ? config.defaultX : 0,
+      y: 'defaultY' in config ? config.defaultY : 0,
       displayBounds
     };
   }
@@ -167,7 +169,9 @@ module.exports = function (options) {
   // Set state fallback values
   state = Object.assign({
     width: config.defaultWidth || 800,
-    height: config.defaultHeight || 600
+    height: config.defaultHeight || 600,
+    x: 'defaultX' in config ? config.defaultX : 0,
+    y: 'defaultY' in config ? config.defaultY : 0
   }, state);
 
   return {

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,14 @@ Note: Don't call this function before the `ready` event is fired.
 
   The height that should be returned if no file exists yet. Defaults to `600`.
 
+`defaultX` - Number | Undefined
+
+  The X position that should be returned if no file exists yet. Defaults to `0`.
+
+`defaultY` - Number | Undefined
+
+  The Y position that should be returned if no file exists yet. Defaults to `0`.
+
 `path` - *String*
 
   The path where the state file should be written to. Defaults to

--- a/test.js
+++ b/test.js
@@ -384,3 +384,16 @@ test('Reset state to default values if saved display is unavailable', t => {
   screen.getPrimaryDisplay.restore();
   screen.getAllDisplays.restore();
 });
+
+test('Set defaultX and defaultY if no state exists', t => {
+  let state = require('.')({defaultX: 100, defaultY: 200});
+
+  t.is(state.x, 100);
+  t.is(state.y, 200);
+
+  state = require('.')({defaultX: undefined, defaultY: undefined});
+
+  t.is(state.x, undefined);
+  t.is(state.y, undefined);
+});
+


### PR DESCRIPTION
This PR adds following options:

- `defaultX`: The X position that should be returned if no file exists yet. Defaults to `0`.
- `defaultY`: The Y position that should be returned if no file exists yet. Defaults to `0`.

Motivation of these options are that I want to specify default position of the window. This library specifies `x: 0, y: 0` as default position, but default position of browser window is not `(0, 0)`. The default position is center of screen.

These options accepts `undefined` because `x` and `y` options in `BrowserWindow`'s constructor accepts `undefined`. When they are set to `undefined`, the window is aligned at center of the screen.

Note that this PR does not break current behavior because their default values are `0`. I added test case for this and updated type definitions also.