### PR TITLE
Only reset window position if it is out of bounds across multiple monitors and allow out of bounds option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,8 @@ declare namespace windowStateKeeper {
         file?: string;
         /** Should we automatically maximize the window, if it was last closed maximized. Defaults to `true`. */
         maximize?: boolean;
+        /** Allow the window to go out of bounds as long as one corner is still in view. */
+        outOfBounds?: boolean;
     }
 
     interface State {

--- a/index.js
+++ b/index.js
@@ -45,21 +45,45 @@ module.exports = function (options) {
     };
   }
 
-  function windowWithinBounds(bounds) {
+  function newPoint(x, y) {
+    return {
+      x,
+      y,
+    };
+  }
+
+  function pointWithinBounds(point, bounds) {
     return (
-      state.x >= bounds.x &&
-      state.y >= bounds.y &&
-      state.x + state.width <= bounds.x + bounds.width &&
-      state.y + state.height <= bounds.y + bounds.height
-    );
+      point.x >= bounds.x &&
+      point.y >= bounds.y &&
+      point.x <= bounds.x + bounds.width &&
+      point.y <= bounds.y + bounds.height
+    )
   }
 
   function ensureWindowVisibleOnSomeDisplay() {
-    const visible = screen.getAllDisplays().some(display => {
-      return windowWithinBounds(display.bounds);
-    });
-
-    if (!visible) {
+    const points = [];
+    points.push(newPoint(state.x, state.y));
+    points.push(newPoint(state.x, state.y + state.height));
+    points.push(newPoint(state.x + state.width, state.y));
+    points.push(newPoint(state.x + state.width, state.y + state.height));
+    const displays = screen.getAllDisplays();
+    const length = displays.length;
+    let valid_point_count = 0;
+    for (let i = 0; i < length; i++) {
+      const curr_display = displays[i];
+      const point_length = points.length;
+      for (let j = 0; j < point_length; j++) {
+        if (pointWithinBounds(points[j], curr_display.bounds)) {
+          valid_point_count++;
+        }
+      }
+      if (valid_point_count === 4) {
+        break;
+      }
+    }
+        
+    if (valid_point_count !== 4) {
       // Window is partially or fully not visible now.
       // Reset it to safe defaults.
       return resetStateToDefault();

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ module.exports = function (options) {
     file: 'window-state.json',
     path: app.getPath('userData'),
     maximize: true,
-    fullScreen: true
+    fullScreen: true,
+    outOfBounds: false
   }, options);
   const fullStoreFileName = path.join(config.path, config.file);
 
@@ -68,22 +69,26 @@ module.exports = function (options) {
     points.push(newPoint(state.x + state.width, state.y));
     points.push(newPoint(state.x + state.width, state.y + state.height));
     const displays = screen.getAllDisplays();
-    const length = displays.length;
-    let valid_point_count = 0;
-    for (let i = 0; i < length; i++) {
-      const curr_display = displays[i];
-      const point_length = points.length;
-      for (let j = 0; j < point_length; j++) {
-        if (pointWithinBounds(points[j], curr_display.bounds)) {
-          valid_point_count++;
+    const displayLength = displays.length;
+    let currentPointCount = 0;
+    let validPointCount = 4;
+    if (config.outOfBounds) {
+      validPointCount = 1;
+    }
+    for (let i = 0; i < displayLength; i++) {
+      const currDisplay = displays[i];
+      const pointLength = points.length;
+      for (let j = 0; j < pointLength; j++) {
+        if (pointWithinBounds(points[j], currDisplay.bounds)) {
+          currentPointCount++;
         }
       }
-      if (valid_point_count === 4) {
+      if (currentPointCount >= validPointCount) {
         break;
       }
     }
         
-    if (valid_point_count !== 4) {
+    if (currentPointCount < validPointCount) {
       // Window is partially or fully not visible now.
       // Reset it to safe defaults.
       return resetStateToDefault();


### PR DESCRIPTION
1.) Add logic to only reset the window if the window is out of bounds of a view in a multi-monitor supported way.

Previously the window position would be reset if the window was in-between two monitors even though it was still visible. This change allows the window to not be reset even if it is between monitors as long as the window is in view.

2.) Allow an `outOfBounds` option that is false by default. When set to true, the window position can be off screen but must maintain at least one corner in view.